### PR TITLE
Make correction to readme usage example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,8 @@ postcss([
   gridSpan({
     columns: 12,
     gap: 30,
-    maxWidth: 1290
+    maxWidth: 1290,
+    appendUnit: true
   })
 ]);
 ```


### PR DESCRIPTION
The output example shows `px` unit so I updated the example settings with the `appendUnit` option.