### PR TITLE
Improve readme documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,8 @@ $ npm install postcss-grid-span
 
 ## Usage
 
+See [PostCSS usage docs] for examples for your environment.
+
 ```js
 const gridSpan = require("postcss-grid-span");
 
@@ -23,7 +25,7 @@ postcss([
 ]);
 ```
 
-See [PostCSS usage docs] for examples for your environment.
+By default, the `span` function outputs a pixel value without the unit. The `px` unit can be appended by setting `appendUnit` to `true` in the plugin’s settings.
 
 #### Input
 
@@ -46,8 +48,8 @@ See [PostCSS usage docs] for examples for your environment.
 | Name | Required | Type | Description |
 | ---- | -------- | ---- | ----------- |
 | `columns` | yes | number | Total number of columns in grid layout, e.g., `12` |
-| `gap` | yes | number | Width of grid gap (gutter), e.g., `30` |
-| `maxWidth` | yes | number | Maximum width of grid container, e.g., `1290` |
+| `gap` | yes | number | Width of grid gap (gutter) in pixels, e.g., `30` |
+| `maxWidth` | yes | number | Maximum width of grid container in pixels, e.g., `1290` |
 | `appendUnit` | no | boolean | Whether or not to append `px` unit onto span values; default value is `false` |
 
 


### PR DESCRIPTION
* Clarify that output values are unitless pixel values by default
* Clarify that `gap` and `maxWidth` values in plugin’s settings are
unitless pixel values