### PR TITLE
Add fluid option to span function

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -15,6 +15,14 @@ function run(input, output, options) {
     });
 }
 
+it("outputs a fluid value", () => {
+  var input = "div { width: span(7 fluid); }";
+  var output = "div { width: 57.36434108527132%; }";
+  var options = grid;
+
+  return run(input, output, options);
+});
+
 it("has unit appended to value", () => {
   var input = "div { width: span(7); }";
   var output = "div { width: 740px; }";

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,62 @@ By default, the `span` function outputs a pixel value without the unit. The `px`
 }
 ```
 
+The `span` function can also calculate and output a percentage value on the fly by passing `fluid` as the second option. Note that if a the percentage value is requested, then the `appendUnit` option will have no effect on the output, even if set to `true`.
+
+#### Input
+
+```css
+.foo {
+  width: span(7 fluid);
+}
+```
+
+#### Output
+
+```css
+.foo {
+  width: 57.36434108527132%;
+}
+```
+
+## Practical example
+
+Here is a practical example of how this plugin can be used to help provide fallback styles for a CSS grid layout.
+
+```css
+/* Set up the grid container */
+.container {
+  max-width: 1290px;
+
+  @supports (display: grid) {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    grid-column-gap: 30px;
+  }
+}
+
+/* Place items on the grid */
+.content {
+  float: left;
+  width: span(7 fluid);
+
+  @supports (display: grid) {
+    grid-column: span 7;
+    width: auto;
+  }
+}
+
+.aside {
+  float: right;
+  width: span(3 fluid);
+
+  @supports (display: grid) {
+    grid-column: 10 / span 3;
+    width: auto;
+  }
+}
+```
+
 ## Options
 
 | Name | Required | Type | Description |


### PR DESCRIPTION
The fluid option allows for output to be changed to a percentage value
on the fly without having to set an option in the plugin’s settings.